### PR TITLE
Feature/configurable help message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
     maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' } // PlaceholderAPI
 
     maven { url 'https://gitlab.com/api/v4/projects/14122684/packages/maven' } // BedWars1058
-    maven { url 'https://dl.bintray.com/tastybento/maven-repo' } // ASkyBlock
+    maven { url 'https://repo.codemc.org/repository/maven-public' } // ASkyBlock
     maven { url 'https://repo.citizensnpcs.co/' } // Citizens
     maven { url 'https://mvn.lumine.io/repository/maven-public/' } // MythicMobs
     maven { url 'https://bitbucket.org/kangarko/libraries/raw/master' } // All mineacademy, e.g BossTM

--- a/src/main/java/io/github/battlepass/commands/bp/HelpSub.java
+++ b/src/main/java/io/github/battlepass/commands/bp/HelpSub.java
@@ -2,23 +2,32 @@ package io.github.battlepass.commands.bp;
 
 import io.github.battlepass.BattlePlugin;
 import io.github.battlepass.commands.BpSubCommand;
+import io.github.battlepass.lang.Lang;
 import me.hyfe.simplespigot.text.Text;
 import org.bukkit.command.CommandSender;
 
 public class HelpSub extends BpSubCommand<CommandSender> {
+    private final String helpMessage;
 
     public HelpSub(BattlePlugin plugin) {
         super(plugin, true);
+
+        Lang lang = plugin.getLang();
+        if (lang.has("help-command")) {
+            this.helpMessage = lang.external("help-command").toString();
+        } else {
+            this.helpMessage = "\n&eBattlePass &7by Hyfe and Zak Shearman\n"
+                    .concat("/battlepass - Opens the portal menu.")
+                    .replace("- ", "&8- &7")
+                    .replace("/battlepass", "&e/battlepass")
+                    .replace(".", ".\n");
+        }
 
         this.addFlatWithAliases("help", "?");
     }
 
     @Override
     public void onExecute(CommandSender sender, String[] strings) {
-        Text.sendMessage(sender, "\n&eBattlePass &7by Hyfe and Zak Shearman\n"
-                .concat("/battlepass - Opens the portal menu.")
-                .replace("- ", "&8- &7")
-                .replace("/battlepass", "&e/battlepass")
-                .replace(".", ".\n"));
+        Text.sendMessage(sender, this.helpMessage);
     }
 }

--- a/src/main/resources/lang.yml
+++ b/src/main/resources/lang.yml
@@ -17,6 +17,14 @@ progress-bar:
   incomplete-color: '&c'
   symbol: '|'
 
+help-command: # /bp help
+  - ''
+  - '&eBattlePass &7by Hyfe and Zak Shearman'
+  - '&e/battlepass - Opens the portal menu.'
+  - '&e/battlepass stats - View your BattlePass stats.'
+  - '&e/battlepass open <portal/daily/quests/rewards> - Directly opens a menu.'
+  - ''
+
 stats-command:
   - '&eYour BattlePass Stats:'
   - '  &8- &ePass Type: &f%pass_type%'


### PR DESCRIPTION
Makes /bp help configurable.
Checks if the value is present in the lang file so there are no errors if users haven't added it.
Added some more commands that were never added to the default help message to the one in the lang.yml.